### PR TITLE
Documentation nits

### DIFF
--- a/src/nopres_intf.ml
+++ b/src/nopres_intf.ml
@@ -120,7 +120,7 @@ module type T = sig
 
   val enforce_strategy : t -> unit
   (** [enforce_strategy ra] forces a reallocation if necessary
-      (e.g. after a [put_strategy]. *)
+      (e.g. after a [put_strategy]). *)
 
 
   (** {6 Copying, blitting and range extraction} *)

--- a/src/pres_intf.ml
+++ b/src/pres_intf.ml
@@ -112,7 +112,7 @@ module type T = sig
 
   val enforce_strategy : 'a t -> unit
   (** [enforce_strategy ra] forces a reallocation if necessary
-      (e.g. after a [put_strategy]. *)
+      (e.g. after a [put_strategy]). *)
 
 
   (** {6 Matrix functions} *)

--- a/src/res.mli
+++ b/src/res.mli
@@ -26,12 +26,13 @@
 
 (** Default strategy for resizable datastructures *)
 module DefStrat : (Strat.T with type t = float * float * int)
-(** [type t] is a triple [waste, shrink_trig, min_size], where
-    [waste] (default: 1.5) indicates by how much the array should
-    be grown in excess when reallocation is triggered, [shrink_trig]
+(** [type t] is a triple [(waste, shrink_trig, min_size)], where
+    [waste] (default: 1.5) indicates how much the array should
+    grow in excess when reallocation is triggered, [shrink_trig]
     (default: 0.5) at which percentage of excess elements it should be
-    shrinked and [min_size] (default: 16 elements) is the minimum size
+    shrunk and [min_size] (default: 16 elements) is the minimum size
     of the resizable array. *)
+
 
 module BitDefStrat : (Strat.T with type t = float * float * int)
 (** Same as [DefStrat], but the minimum size is 1024 elements (bits). *)

--- a/src/strat.ml
+++ b/src/strat.ml
@@ -46,6 +46,6 @@ module type T = sig
       not necessary to resize.
 
       Be careful, the new (real) length {b must} be larger than the new
-      (virtual) length, otherwise your program may crash!
+      virtual length [new_len], otherwise your program may crash!
   *)
 end

--- a/src/weak_intf.ml
+++ b/src/weak_intf.ml
@@ -115,7 +115,7 @@ module type T = sig
 
   val enforce_strategy : 'a t -> unit
   (** [enforce_strategy ra] forces a reallocation if necessary
-      (e.g. after a [put_strategy]. *)
+      (e.g. after a [put_strategy]). *)
 
 
   (** {6 Copying, blitting and range extraction} *)


### PR DESCRIPTION
The documentation for [grow](http://mmottl.github.io/res/api/res/Res__/Strat/module-type-T/index.html#val-grow) and [shrink](http://mmottl.github.io/res/api/res/Res__/Strat/module-type-T/index.html#val-shrink) confused me upon first reading as they seemed similar but the function names were obviously very different.

The direct reference to **new_len** helped to clarify it for me.