### PR TITLE
Remove `base-bytes` dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,6 +18,5 @@
 RES is a library containing resizable arrays, strings, and bitvectors.")
   (depends
     (ocaml (>= 4.08))
-    base-bytes
   )
 )

--- a/res.opam
+++ b/res.opam
@@ -12,7 +12,6 @@ bug-reports: "https://github.com/mmottl/res/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "base-bytes"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
It is not used to get the `bytes` library, nor is it necessary since OCaml 4.02 (the lowest version dune supports).

This decreases the dependency cone by not requiring `ocamlfind` transitively.